### PR TITLE
Fixed Inability to Select Prior Item

### DIFF
--- a/StrictXAML/StrictComboBox.cs
+++ b/StrictXAML/StrictComboBox.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Controls;
@@ -36,6 +37,12 @@ namespace StrictXAML
         }
 
         private static object CoerceValueCallback(DependencyObject o, object value) => value;
+
+        protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == NotifyCollectionChangedAction.Add) QueueRestoreValidState();
+            base.OnItemsChanged(e);
+        }
 
         protected override void OnSelectionChanged(SelectionChangedEventArgs e)
         {

--- a/StrictXAML/StrictComboBox.cs
+++ b/StrictXAML/StrictComboBox.cs
@@ -32,7 +32,10 @@ namespace StrictXAML
         static StrictComboBox()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(StrictComboBox), new FrameworkPropertyMetadata(typeof(ComboBox)));
+            SelectedItemProperty.OverrideMetadata(typeof(StrictComboBox), new FrameworkPropertyMetadata(null, null, CoerceValueCallback));
         }
+
+        private static object CoerceValueCallback(DependencyObject o, object value) => value;
 
         protected override void OnSelectionChanged(SelectionChangedEventArgs e)
         {


### PR DESCRIPTION
This PR overrides the CoerceValueCallback for the SelectedItemProperty. The override prevents the ComboBox class from cancelling a change to SelectedItem which would allow the user to select a new option if the option being transitioned to is not available in the ItemsSource.

Closes #3