### PR TITLE
Added SDK Configuration

### DIFF
--- a/StrictXAML.Maui/global.json
+++ b/StrictXAML.Maui/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Due to a recent VS/Build Tools update, the .NET 7 SDK has been removed. In order to build .NET 7 projects, we have to explicitly configure the build to use the .NET 8 (or higher) SDK.