### PR TITLE
Change Target Frameworks for MAUI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Install workloads
       run: dotnet workload restore
     - name: Restore dependencies

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Install workloads
       run: dotnet workload restore
     - name: Restore dependencies

--- a/StrictXAML.Maui/StrictXAML.Maui.csproj
+++ b/StrictXAML.Maui/StrictXAML.Maui.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UseMaui>true</UseMaui>


### PR DESCRIPTION
This drops support for .NET 7 and adds support for .NET 9. It is _possible_ to still build and package .NET 7 along with the other two versions, but it's complicated since no .NET SDK can build both .NET 7 and .NET 9. Anyone consuming the .NET 7 package will just have to stick with 1.3.0.